### PR TITLE
Review comments

### DIFF
--- a/src/gearman-client.cpp
+++ b/src/gearman-client.cpp
@@ -100,6 +100,7 @@ gearman_return_t GearmanClient::processJob(gearman_job_st *job_ptr, std::string&
     struct curl_slist *headerlist = nullptr;
     gearman_return_t gearman_ret = GEARMAN_SUCCESS;
     time_t start_ts = time(nullptr);
+    //What's the reason for sending a blank Expect: header?
     static const char expect_buf[] = "Expect:";
     std::stringstream raw_resp;
     const char *job_function_name = static_cast<const char *>(gearman_job_function_name(job_ptr));
@@ -190,16 +191,18 @@ gearman_return_t GearmanClient::processJob(gearman_job_st *job_ptr, std::string&
         LOG4CXX_ERROR(ThreadLogger, "Unable to add unique to post: " << formerror);
         goto error;
     }
+    //job_workload is available, is the reason for explicit content length sizing to allow for null characters in workloads? could this be:
+    //formerror = curl_formadd(&formpost, &lastptr, CURLFORM_PTRNAME, "workload", CURLFORM_PTRCONTENTS, job_workload.c_str()) ?
     if ((formerror = curl_formadd(&formpost, &lastptr, CURLFORM_PTRNAME, "workload", CURLFORM_PTRCONTENTS, gearman_job_workload(job_ptr), CURLFORM_CONTENTSLENGTH, gearman_job_workload_size(job_ptr), CURLFORM_END)) != 0) {
         LOG4CXX_ERROR(ThreadLogger, "Unable to add workload to post: " << formerror);
         goto error;
     }
 
-    /* Do it! */
     if (curl_easy_setopt(curl, CURLOPT_HTTPPOST, formpost) != 0) {
         LOG4CXX_ERROR(ThreadLogger, "Unable to set form POST data");
         goto error;
     }
+    /* Do it! */
     res = curl_easy_perform(curl);
     if (res != CURLE_OK) {
         LOG4CXX_ERROR(ThreadLogger, "Failed to perform curl. Error: " << curl_easy_strerror(res) << " Message: " << error_buf);
@@ -224,6 +227,8 @@ gearman_return_t GearmanClient::processJob(gearman_job_st *job_ptr, std::string&
                 LOG4CXX_ERROR(ThreadLogger, "Malformed response from worker: " << raw_resp.str());
                 goto error;
             }
+            //what constant does the literal value 0 map to?
+            //(though I guess it doesn't matter as we already checked for it's presence in the conditional above?)
             gearman_ret = (gearman_return_t)(tree.get("gearman_ret", 0).asInt());
             return_string.append(tree.get("response_string", "").asString());
 
@@ -231,6 +236,8 @@ gearman_return_t GearmanClient::processJob(gearman_job_st *job_ptr, std::string&
                                        << " workload=" << job_workload
                                        << " return_code=" << gearman_ret << " response_string=" << return_string);
         } catch (...) {
+            //is it possible to reference the exception encountered here? this message doesn't give much
+            //to go on
             LOG4CXX_ERROR(ThreadLogger, "Unable to parse response due to unexpected exception");
             goto error;
         }

--- a/src/gearman-client.cpp
+++ b/src/gearman-client.cpp
@@ -128,15 +128,15 @@ gearman_return_t GearmanClient::processJob(gearman_job_st *job_ptr, std::string&
         goto error;
     }
     if (curl_easy_setopt(curl, CURLOPT_TCP_KEEPALIVE, 1) != 0) {
-        LOG4CXX_ERROR(ThreadLogger, "Unable to set nosignal");
+        LOG4CXX_ERROR(ThreadLogger, "Unable to set tcp_keepalive");
         goto error;
     }
     if (curl_easy_setopt(curl, CURLOPT_TCP_KEEPIDLE, 120L) != 0) {
-        LOG4CXX_ERROR(ThreadLogger, "Unable to set nosignal");
+        LOG4CXX_ERROR(ThreadLogger, "Unable to set tcp_keepidle");
         goto error;
     }
     if (curl_easy_setopt(curl, CURLOPT_TCP_KEEPINTVL, 60L) != 0) {
-        LOG4CXX_ERROR(ThreadLogger, "Unable to set nosignal");
+        LOG4CXX_ERROR(ThreadLogger, "Unable to set tcp_keepintvl");
         goto error;
     }
     if (curl_easy_setopt(curl, CURLOPT_URL, m_http_uri.c_str()) != 0) {

--- a/src/main-loop.cpp
+++ b/src/main-loop.cpp
@@ -203,6 +203,7 @@ bool MainLoop::loadConfig(DriveshaftConfig& new_config) noexcept {
 
     if (sb.st_mtime > m_config.m_load_time) {
         LOG4CXX_INFO(MainLogger, "Reloading config");
+        //what's the difference between using a boost::property_tree here vs. Json::Value in gearman-client?
         namespace pt = boost::property_tree;
         pt::ptree tree;
         try {


### PR DESCRIPTION
This adds additional information when the HTTP request fails (though there might be memory concerns allocating `char error_buf[CURL_ERROR_SIZE];` on every call), fixes up some error messages and adds some questions in the form of code comments.
