### PR TITLE
add proper versioning information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ driveshaft_unit_tests
 CTestTestfile.cmake
 Testing/
 *.a
+src/version.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ SET(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMake" ${CMAKE_MODULE_PATH})
 
 # package information
 SET(PACKAGE_NAME      "driveshaft")
-SET(PACKAGE_VERSION   "0.1")
+SET(PACKAGE_VERSION   "0.1.0")
 SET(PACKAGE_STRING    "${PACKAGE_NAME} ${PACKAGE_VERSION}")
 SET(PACKAGE_TARNAME   "${PACKAGE_NAME}-${PACKAGE_VERSION}")
 SET(PACKAGE_BUGREPORT "https://github.com/keyurdg/driveshaft/issues")
@@ -27,6 +27,10 @@ include(FindLog4cxx)
 MARK_AS_ADVANCED(CLEAR CMAKE_INSTALL_PREFIX)
 
 INCLUDE(CheckFunctionExists)
+
+FILE(WRITE src/version.h
+  "\#ifndef DRIVESHAFT_VERSION\n\#define DRIVESHAFT_VERSION \"@PACKAGE_VERSION@\"\n\#endif\n"
+  )
 
 ADD_SUBDIRECTORY(tests/unit/gtest-1.7.0)
 ADD_SUBDIRECTORY(src)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,7 @@
 #include <log4cxx/helpers/exception.h>
 #include "common-defs.h"
 #include "main-loop.h"
+#include "version.h"
 
 namespace Driveshaft {
 
@@ -49,6 +50,7 @@ int main(int argc, char **argv) {
     po::options_description desc("Allowed options");
     desc.add_options()
             ("help", "produce help message")
+            ("version", "print version string")
             ("jobsconfig", po::value<std::string>(&jobs_config_file), "jobs config file path")
             ("logconfig", po::value<std::string>(&log_config_file), "log config file path")
             ("max_running_time", po::value<uint32_t>(&Driveshaft::MAX_JOB_RUNNING_TIME), "how long can a job run before it is considered failed (in seconds)")
@@ -60,6 +62,10 @@ int main(int argc, char **argv) {
         po::variables_map vm;
         po::store(po::parse_command_line(argc, argv, desc), vm);
         po::notify(vm);
+        if (vm.count("version")) {
+            std::cout << "driveshaft version: " DRIVESHAFT_VERSION << std::endl;
+            return 1;
+        }
         if (vm.empty()
             || vm.count("help")
             || !vm.count("jobsconfig")

--- a/src/version.h
+++ b/src/version.h
@@ -1,0 +1,3 @@
+#ifndef DRIVESHAFT_VERSION
+#define DRIVESHAFT_VERSION "0.1.0"
+#endif

--- a/src/version.h
+++ b/src/version.h
@@ -1,3 +1,0 @@
-#ifndef DRIVESHAFT_VERSION
-#define DRIVESHAFT_VERSION "0.1.0"
-#endif


### PR DESCRIPTION
this adds a CMAKE rule to generate a version file from the PACKAGE_VERSION
information in the CMakeLists file. This is then included in the main.cpp to
also show the version via the `--version` flag so it's easy to check which
version you are running.
