### PR TITLE
first pass at adding metrics library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,10 @@ before_install:
 - sudo add-apt-repository ppa:apokluda/boost1.53 -y
 - sudo add-apt-repository ppa:gearman-developers/ppa -y
 - sudo add-apt-repository ppa:ondrej/php5 -y
+- curl -s https://packagecloud.io/install/repositories/mrtazz/snyder/script.deb.sh | sudo bash
 - sudo apt-get update
 - sudo apt-get install -qq build-essential gcc-4.8 g++-4.8 clang liblog4cxx10-dev libboost1.53-all-dev php-pear php5-dev
 - sudo apt-get install libgearman-dev gearman-job-server gearman libgearman7
 - sudo apt-get install libcurl4-openssl-dev
+- sudo apt-get install snyder
 - sudo pecl install gearman

--- a/CMake/FindSnyder.cmake
+++ b/CMake/FindSnyder.cmake
@@ -1,0 +1,18 @@
+FIND_PATH(SNYDER_INCLUDE_DIR NAMES snyder/metrics_registry.h PATHS /usr/include /usr/local/include)
+
+FIND_LIBRARY(SNYDER_LIBRARY NAMES snyder PATHS /usr/lib64 /usr/local/lib64)
+
+IF (SNYDER_INCLUDE_DIR)
+  MESSAGE(STATUS "Snyder Include dir: ${SNYDER_INCLUDE_DIR}")
+ELSE()
+  MESSAGE(FATAL_ERROR "Cannot find snyder includedir")
+ENDIF()
+
+IF (SNYDER_LIBRARY)
+  MESSAGE(STATUS "libsnyder library: ${SNYDER_LIBRARY}")
+ELSE()
+  MESSAGE(FATAL_ERROR "Cannot find libsnyder library")
+ENDIF()
+
+include_directories(${SNYDER_INCLUDE_DIR})
+LIST(APPEND DRIVESHAFT_LINK_LIBRARIES snyder)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ include(FindGearman)
 include(FindPThread)
 include(GetBoost)
 include(FindLog4cxx)
+include(FindSnyder)
 
 MARK_AS_ADVANCED(CLEAR CMAKE_INSTALL_PREFIX)
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 * libcurl(-devel)
 * boost(-devel) 1.48 or later
 * gcc 4.8 or later
+* [snyder](https://github.com/mrtazz/snyder) 0.4.0 or later for metrics
 
 ## Build
 ```
@@ -105,7 +106,7 @@ shutdown wait durations (hard shutdown is 2x, and graceful is 4x this value).
 
 ## status port
 The server listens on `status_port` and currently supports the command `threads`.
-For every running thread, the server returns back text formatted as 
+For every running thread, the server returns back text formatted as
 `<Thread-ID>\t<Pool-Name>\t<Shutdown-Flag>\tjob_handle=<Job-Handle> job_unique=<Job-Unique>\r\n`
 
 # Design

--- a/src/main-loop.cpp
+++ b/src/main-loop.cpp
@@ -33,6 +33,7 @@
 #include <boost/range/algorithm/copy.hpp>
 #include <boost/range/adaptors.hpp>
 #include <boost/asio.hpp>
+#include <snyder/metrics_registry.h>
 #include <exception>
 #include <utility>
 #include <mutex>
@@ -44,6 +45,8 @@
 #include "status-loop.h"
 
 namespace Driveshaft {
+
+  extern Snyder::MetricsRegistry* MetricsRegistry;
 
 MainLoop::MainLoop(const std::string& config_file) noexcept
     : m_config_filename(config_file)
@@ -255,6 +258,8 @@ void MainLoop::modifyPool(const std::string& name) noexcept {
             t.detach();
         }
     }
+    Driveshaft::MetricsRegistry->Gauge("running_workers_" + name,
+                                      (uint64_t)m_thread_registry->poolCount(name));
 }
 
 static const char* CONFIG_KEY_GEARMAN_SERVERS_LIST = "gearman_servers_list";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,6 +43,7 @@
 #include <log4cxx/propertyconfigurator.h>
 #include <log4cxx/xml/domconfigurator.h>
 #include <log4cxx/helpers/exception.h>
+#include <snyder/metrics_registry.h>
 #include "common-defs.h"
 #include "main-loop.h"
 #include "version.h"
@@ -53,6 +54,9 @@ namespace Driveshaft {
 static const char* MAIN_LOGGER_NAME = "Main";
 static const char* THREAD_LOGGER_NAME = "Thread";
 static const char* STATUS_LOGGER_NAME = "Status";
+
+// globally accesible metrics registry
+Snyder::MetricsRegistry* MetricsRegistry = new Snyder::MetricsRegistry();
 
 /* Define the externs from common-defs */
 std::atomic_bool g_force_shutdown;

--- a/src/status-loop.cpp
+++ b/src/status-loop.cpp
@@ -62,10 +62,10 @@ using namespace std::placeholders;
 static const std::string CR("\r");
 static const std::string STATUS_COMMAND_THREADS("threads");
 static const std::string STATUS_COMMAND_THREADS_CR(STATUS_COMMAND_THREADS + CR);
-// static const std::string STATUS_COMMAND_COUNTERS = "counters";
-// static const std::string STATUS_COMMAND_COUNTERS_CR(STATUS_COMMAND_COUNTERS + CR);
-// static const std::string STATUS_COMMAND_GAUGES("gauges");
-// static const std::string STATUS_COMMAND_GAUGES_CR(STATUS_COMMAND_GAUGES + CR);
+static const std::string STATUS_COMMAND_COUNTERS = "counters";
+static const std::string STATUS_COMMAND_COUNTERS_CR(STATUS_COMMAND_COUNTERS + CR);
+static const std::string STATUS_COMMAND_GAUGES("gauges");
+static const std::string STATUS_COMMAND_GAUGES_CR(STATUS_COMMAND_GAUGES + CR);
 
 class StatusResponder : public std::enable_shared_from_this<StatusResponder> {
 private:
@@ -102,6 +102,22 @@ private:
                     const auto &data = i.second;
                     os << i.first << "\t" << data.pool << "\t" << data.should_shutdown << "\t" << data.state << "\r\n";
                 }
+            } else if (!input.compare(STATUS_COMMAND_COUNTERS)
+                || !input.compare(STATUS_COMMAND_COUNTERS_CR)) {
+
+              LOG4CXX_DEBUG(StatusLogger, "Getting counters snapshot and sending it back.");
+              auto counters = Driveshaft::MetricsRegistry->GetCounters();
+              for (auto& kv : counters) {
+                    os << kv.first << ": " << kv.second << std::endl;
+              }
+            } else if (!input.compare(STATUS_COMMAND_GAUGES)
+                || !input.compare(STATUS_COMMAND_GAUGES_CR)) {
+
+              LOG4CXX_DEBUG(StatusLogger, "Getting gauges snapshot and sending it back.");
+              auto gauges = Driveshaft::MetricsRegistry->GetGauges();
+              for (auto& kv : gauges) {
+                    os << kv.first << ": " << kv.second << std::endl;
+              }
             } else {
                 os << "Error: unrecognized command\r\n";
             }

--- a/src/status-loop.h
+++ b/src/status-loop.h
@@ -27,9 +27,12 @@
 #define incl_DRIVESHAFT_STATUS_LOOP_H_
 
 #include <boost/asio.hpp>
+#include <snyder/metrics_registry.h>
 #include "thread-registry.h"
 
 namespace Driveshaft {
+
+  extern Snyder::MetricsRegistry* MetricsRegistry;
 
 class StatusLoop {
 


### PR DESCRIPTION
this adds a simple metrics library that makes it possible to track counts and
gauges for now. It makes it accessible as a variable directly in the
Driveshaft namespace. And the status loop has been extended to print all
counters and gauges for the "counters" and "gauges" commands respectively.

As an example it only tracks pool size for now, which is kinda redundant to
the "threads" command but a good example.
