### PR TITLE
Add depool feature

### DIFF
--- a/src/driveshaft-config.cpp
+++ b/src/driveshaft-config.cpp
@@ -22,7 +22,8 @@ DriveshaftConfig::DriveshaftConfig() noexcept :
 }
 
 bool DriveshaftConfig::load(const std::string& config_filename, std::shared_ptr<Json::CharReader> json_parser) {
-    if (!this->needsConfigUpdate(config_filename)) {
+    if (!this->needsDepoolOrRepool() &&
+        !this->needsConfigUpdate(config_filename)) {
         return false;
     }
 
@@ -90,6 +91,17 @@ void DriveshaftConfig::clearAllWorkerCounts(PoolWatcher& watcher) {
     for (const auto& i : this->m_pool_map) {
         this->clearWorkerCount(i.first, watcher);
     }
+}
+
+uint32_t DriveshaftConfig::getWorkerCount(const std::string& pool_name) const {
+    auto pool_iter = this->m_pool_map.find(pool_name);
+    if (pool_iter == this->m_pool_map.end()) {
+        LOG4CXX_ERROR(MainLogger, "getWorkerCount requested, " << pool_name << " does not exist in config");
+        throw std::runtime_error("invalid config detected in getWorkerCount");
+    }
+
+    auto& pool_data = pool_iter->second;
+    return pool_data.worker_count;
 }
 
 std::pair<StringSet, StringSet> DriveshaftConfig::compare(const DriveshaftConfig& that) const noexcept {
@@ -164,6 +176,7 @@ void DriveshaftConfig::parseServerList(const Json::Value& node) {
 
 void DriveshaftConfig::parsePoolList(const Json::Value& node) {
     const auto& pools_list = node[cfgkeys::POOLS_LIST];
+
     for (auto i = pools_list.begin(); i != pools_list.end(); ++i) {
         const auto& pool_name = i.name();
         const auto& pool_node = *i;
@@ -187,7 +200,9 @@ void DriveshaftConfig::parsePoolList(const Json::Value& node) {
         }
 
         auto& pool_data = this->m_pool_map[pool_name];
-        pool_data.worker_count = pool_node[cfgkeys::POOL_WORKER_COUNT].asUInt();
+        pool_data.worker_count = this->m_is_depooled
+            ? 0
+            : pool_node[cfgkeys::POOL_WORKER_COUNT].asUInt();
         pool_data.job_processing_uri = pool_node[cfgkeys::POOL_JOB_PROCESSING_URI].asString();
         LOG4CXX_DEBUG(
             MainLogger,
@@ -222,6 +237,15 @@ bool DriveshaftConfig::needsConfigUpdate(const std::string& new_config_filename)
     }
 
     return modified_time > this->m_load_time;
+}
+
+bool DriveshaftConfig::needsDepoolOrRepool() {
+    bool fileExists = this->depoolFileExists();
+    if (this->m_is_depooled != fileExists) {
+        this->m_is_depooled = fileExists;
+        return true;
+    }
+    return false;
 }
 
 std::string DriveshaftConfig::fetchFileContents(const std::string& filename) const {
@@ -264,6 +288,31 @@ bool DriveshaftConfig::validateConfigNode(const Json::Value& node) const {
     }
 
     return true;
+}
+
+std::time_t DriveshaftConfig::getConfigModTime() const {
+    return this->m_load_time;
+}
+
+void DriveshaftConfig::setConfigModTime(std::time_t t) {
+    this->m_load_time = t;
+}
+
+bool DriveshaftConfig::getDepooled() const {
+    return this->m_is_depooled;
+}
+
+void DriveshaftConfig::setDepooled(bool depooled) {
+    this->m_is_depooled = depooled;
+}
+
+void DriveshaftConfig::setDepoolFile(const std::string& depool_file) {
+    this->m_depool_filename = depool_file;
+}
+
+bool DriveshaftConfig::depoolFileExists() const {
+    return !this->m_depool_filename.empty()
+        && boost::filesystem::exists(this->m_depool_filename);
 }
 
 } // namespace Driveshaft

--- a/src/driveshaft-config.cpp
+++ b/src/driveshaft-config.cpp
@@ -18,7 +18,9 @@ DriveshaftConfig::DriveshaftConfig() noexcept :
     m_config_filename(),
     m_server_list(),
     m_pool_map(),
-    m_load_time(0) {
+    m_load_time(0),
+    m_depool_filename(),
+    m_is_depooled(false) {
 }
 
 bool DriveshaftConfig::load(const std::string& config_filename, std::shared_ptr<Json::CharReader> json_parser) {

--- a/src/driveshaft-config.h
+++ b/src/driveshaft-config.h
@@ -31,13 +31,24 @@ public:
 
     std::pair<StringSet, StringSet> compare(const DriveshaftConfig& that) const noexcept;
 
+    uint32_t getWorkerCount(const std::string& pool_name) const;
+
+    void setDepoolFile(const std::string& depool_file);
+    void setDepooled(bool depooled);
+    bool getDepooled() const;
+
+    void setConfigModTime(std::time_t t);
+    std::time_t getConfigModTime() const;
+
 private:
     void parseServerList(const Json::Value& node);
     void parsePoolList(const Json::Value& node);
 
     bool needsConfigUpdate(const std::string& new_config_filename) const;
+    bool needsDepoolOrRepool();
     std::string fetchFileContents(const std::string& filename) const;
     bool validateConfigNode(const Json::Value& node) const;
+    bool depoolFileExists() const;
 
     typedef struct {
         uint32_t worker_count;
@@ -50,6 +61,8 @@ private:
     StringSet m_server_list;
     PoolMap m_pool_map;
     std::time_t m_load_time;
+    std::string m_depool_filename;
+    bool m_is_depooled;
 };
 
 } // namespace Driveshaft

--- a/src/main-loop.cpp
+++ b/src/main-loop.cpp
@@ -172,10 +172,11 @@ void MainLoop::run() {
         new_config.setDepoolFile(this->m_depool_filename);
         new_config.setConfigModTime(m_config.getConfigModTime());
         new_config.setDepooled(m_config.getDepooled());
-        new_config.load(this->m_config_filename, json_parser);
 
-        new_config.supersede(m_config, *m_pool_watcher);
-        m_config = new_config;
+        if (new_config.load(this->m_config_filename, json_parser)) {
+            new_config.supersede(m_config, *m_pool_watcher);
+            m_config = new_config;
+        }
 
         std::this_thread::sleep_for(std::chrono::seconds(LOOP_SLEEP_DURATION));
     }

--- a/src/main-loop.cpp
+++ b/src/main-loop.cpp
@@ -110,8 +110,11 @@ private:
     MetricProxyPtr m_metrics_proxy;
 };
 
-MainLoop::MainLoop(const std::string &config_file, const std::string &exporter_addr) :
+MainLoop::MainLoop(const std::string &config_file,
+    const std::string &exporter_addr,
+    const std::string &depool_file) :
     m_config_filename(config_file),
+    m_depool_filename(depool_file),
     m_config(),
     m_thread_registry(new ThreadRegistry),
     m_metric_proxy(new MetricProxy(exporter_addr)),
@@ -166,6 +169,9 @@ void MainLoop::run() {
         }
 
         DriveshaftConfig new_config;
+        new_config.setDepoolFile(this->m_depool_filename);
+        new_config.setConfigModTime(m_config.getConfigModTime());
+        new_config.setDepooled(m_config.getDepooled());
         new_config.load(this->m_config_filename, json_parser);
 
         new_config.supersede(m_config, *m_pool_watcher);

--- a/src/main-loop.h
+++ b/src/main-loop.h
@@ -41,7 +41,7 @@ class MainLoop {
 public:
     // treat this class as a singleton. you really, really don't want more
     // than one in your process.
-    MainLoop(const std::string &config_file, const std::string &exporter_addr);
+    MainLoop(const std::string &config_file, const std::string &exporter_addr, const std::string &depool_file);
     void run();
     ~MainLoop() = default;
 
@@ -56,6 +56,7 @@ private:
     MainLoop& operator=(const MainLoop&&) = delete;
 
     std::string m_config_filename;
+    std::string m_depool_filename;
     DriveshaftConfig m_config;
     ThreadRegistryPtr m_thread_registry;
     MetricProxyPtr m_metric_proxy;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -125,6 +125,7 @@ int main(int argc, char **argv) {
     std::string pid_filename;
     bool daemonize = false;
     std::string exporter_addr;
+    std::string depool_file;
 
     /* Parse command line opts */
     namespace po = boost::program_options;
@@ -140,6 +141,7 @@ int main(int argc, char **argv) {
             ("max_running_time", po::value<uint32_t>(&Driveshaft::MAX_JOB_RUNNING_TIME)->required(), "how long can a job run before it is considered failed (in seconds)")
             ("loop_timeout", po::value<uint32_t>(&Driveshaft::GEARMAND_RESPONSE_TIMEOUT)->required(), "how long to wait for a response from gearmand before restarting event-loop (in seconds)")
             ("exporter_addr", po::value<std::string>(&exporter_addr)->default_value("0.0.0.0:8888"), "the address:port on which to launch a prometheus exporter to publish metrics")
+            ("depool_file", po::value<std::string>(&depool_file)->default_value(""), "when file exists, all worker counts go to 0")
     ;
 
     try {
@@ -203,7 +205,7 @@ int main(int argc, char **argv) {
         LOG4CXX_INFO(Driveshaft::MainLogger, "Starting up with gearmand response timeout=" << Driveshaft::GEARMAND_RESPONSE_TIMEOUT
                                              << " and max running time=" << Driveshaft::MAX_JOB_RUNNING_TIME);
 
-        Driveshaft::MainLoop loop(jobs_config_file, exporter_addr);
+        Driveshaft::MainLoop loop(jobs_config_file, exporter_addr, depool_file);
         loop.run();
     } catch (std::exception& e) {
         std::cout << "MainLoop threw exception: " << e.what() << std::endl;

--- a/tests/unit/test_driveshaft_config.cpp
+++ b/tests/unit/test_driveshaft_config.cpp
@@ -139,3 +139,15 @@ TEST_F(DriveshaftConfigTest, TestSupersedeNotifiesPoolWatcher) {
     ASSERT_EQ(std::make_pair(poolRemoved, uint32_t(0)), watcher.callbacksSeen[0]);
     ASSERT_EQ(std::make_pair(poolAdded, uint32_t(5)), watcher.callbacksSeen[1]);
 }
+
+TEST_F(DriveshaftConfigTest, TestDepool) {
+    DriveshaftConfig config;
+
+    config.setDepooled(true);
+    config.parseConfig(testConfigOneServerOnePool, json_parser);
+    ASSERT_EQ(0, config.getWorkerCount("test-pool-1"));
+
+    config.setDepooled(false);
+    config.parseConfig(testConfigOneServerOnePool, json_parser);
+    ASSERT_EQ(5, config.getWorkerCount("test-pool-1"));
+}


### PR DESCRIPTION
* Add `depool_file` cli flag
* When flag is a non-empty string and the file exists, set all worker counts to 0 on the next config reload. Undo if file disappears.
* Hooks into the existing main loop here: https://github.com/keyurdg/driveshaft/blob/4e4facd124d8f91841ff66d36fac21d2cf7f93c9/src/main-loop.cpp#L169